### PR TITLE
Fixed deprecated hook + Fixes process.cwd issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,9 +57,12 @@ module.exports = class ServerlessApigS3 extends ServerlessAWSPlugin {
     }
 
     async mergeApigS3Resources() {
+        const oldCwd = process.cwd();
         const ownResources = await this.serverless.yamlParser.parse(
             path.resolve(__dirname, 'resources.yml')
         );
+
+        process.chdir(oldCwd);
 
         const withIndex = get(this.serverless, 'service.custom.apigs3.withIndex', true);
         if(!withIndex) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = class ServerlessApigS3 extends ServerlessAWSPlugin {
         };
 
         this.hooks = {
-            'before:deploy:createDeploymentArtifacts': () => this.mergeApigS3Resources(),
+            'before:package:createDeploymentArtifacts': () => this.mergeApigS3Resources(),
             'client:client': () => { this.serverless.cli.log(this.commands.client.usage); },
             'client:deploy:deploy': () => this.deploy()
         };


### PR DESCRIPTION
Hi,

first of all thanks a lot for the plugin, it's exactly what I was looking for...

By the way, I noticed 2 issues:
- the hook for the creation of the configuration to be deployed had a deprecated issue
- while reading the 'resources.yml', the serverless lib changes the cwd (Current Working Directory) of the process, so every action involving the filesystem after that resulted in an error. Unfortunatelly using only this plugin didn't trigger anything, but using it with something like serverless-webpack BOOM, nothing works.

I've fixed both issue and now it works correctly...

Cya
Zweer